### PR TITLE
WIP: Register-based VM

### DIFF
--- a/vm/callinfo.go
+++ b/vm/callinfo.go
@@ -1,0 +1,7 @@
+package vm
+
+// CallInfo is a struct representing the call information.
+type CallInfo struct {
+	function, top  int
+	previous, next *CallInfo
+}

--- a/vm/opcode/instruction.go
+++ b/vm/opcode/instruction.go
@@ -1,0 +1,78 @@
+package opcode
+
+const (
+	sizeC = 20
+	sizeB = 20
+	sizeA = 16
+
+	sizeOp = 8
+
+	posOp = 0
+	posA  = posOp + sizeOp
+	posC  = posA + sizeA
+	posB  = posC + sizeC
+
+	maxArgA = 1<<sizeA - 1
+	maxArgB = 1<<sizeB - 1
+	maxArgC = 1<<sizeC - 1
+
+	bitRK      = 1 << (sizeB - 1)
+	maxIndexRK = bitRK - 1
+)
+
+func isK(x int) bool   { return x&bitRK != 0 }
+func indexK(x int) int { return x & ^bitRK }
+func rkAsK(x int) int  { return x | bitRK }
+
+// creates a mask with 'n' 1 bits at position 'p'
+func mask1(n, p uint) Instruction { return ^(^Instruction(0) << n) << p }
+
+// creates a mask with 'n' 0 bits at position 'p'
+func mask0(n, p uint) Instruction { return ^mask1(n, p) }
+
+// Instruction is a Gates VM instruction. The instruction
+// layout is similar to Lua; however, a Gates VM instruction
+// occupies 64 bits instead of 32 bits:
+//
+//     +--------------+----------+-----------+-----------+
+//     | opcode (0-7) | A (8-23) | B (24-43) | C (44-63) |
+//     +--------------+----------+-----------+-----------+
+type Instruction uint64
+
+func (i Instruction) arg(pos, size uint) int { return int(i >> pos & mask1(size, 0)) }
+
+func (i *Instruction) setArg(pos, size uint, arg int) {
+	*i = *i&mask0(size, pos) | Instruction(arg)<<pos&mask1(size, pos)
+}
+
+// Opcode returns the opcode of the instruction.
+func (i Instruction) Opcode() Opcode { return Opcode(i >> posOp & (1<<sizeOp - 1)) }
+
+// SetOpcode updates the opcode of the instruction.
+func (i *Instruction) SetOpcode(op Opcode) { i.setArg(posOp, sizeOp, int(op)) }
+
+// A returns the A of the instruction.
+func (i Instruction) A() int { return int(i >> posA & maxArgA) }
+
+// SetA updates the A of the instruction.
+func (i *Instruction) SetA(x int) { i.setArg(posA, sizeA, x) }
+
+// B returns the B of the instruction.
+func (i Instruction) B() int { return int(i >> posB & maxArgB) }
+
+// SetB updates the B of the instruction.
+func (i *Instruction) SetB(x int) { i.setArg(posB, sizeB, x) }
+
+// C returns the C of the instruction.
+func (i Instruction) C() int { return int(i >> posC & maxArgC) }
+
+// SetC updates the C of the instruction.
+func (i *Instruction) SetC(x int) { i.setArg(posC, sizeC, x) }
+
+// NewABC creates an instruction in ABC-form.
+func NewABC(op Opcode, a, b, c int) Instruction {
+	return Instruction(op)<<posOp |
+		Instruction(a)<<posA |
+		Instruction(b)<<posB |
+		Instruction(c)<<posC
+}

--- a/vm/opcode/opcode.go
+++ b/vm/opcode/opcode.go
@@ -1,0 +1,32 @@
+package opcode
+
+// Opcode is the portion of Gates VM instruction that
+// specifies the operation to be performed.
+type Opcode int
+
+// Opcode could be one of the values below:
+const (
+	Move Opcode = iota
+	LoadK
+	LoadBool
+	LoadNull
+	GetUpVal
+
+	GetGlobal
+	GetTable
+
+	SetGlobal
+	SetUpVal
+	SetTable
+
+	NewMap
+	NewArray
+
+	Add
+	Sub
+	Mul
+	Div
+	Pow
+	Unm
+	Not
+)

--- a/vm/repr.go
+++ b/vm/repr.go
@@ -1,0 +1,93 @@
+package vm
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"unsafe"
+)
+
+// Represent returns a string containing a printable representation
+// of a value.
+func Represent(x Value) string {
+	return represent(x, make(map[unsafe.Pointer]struct{}))
+}
+
+func represent(x Value, visited map[unsafe.Pointer]struct{}) string {
+	v := reflect.ValueOf(x)
+	switch v.Kind() {
+	case reflect.Map, reflect.Slice:
+		addr := unsafe.Pointer(v.Pointer())
+		if _, seen := visited[addr]; seen {
+			return "[Circular]"
+		}
+		visited[addr] = struct{}{}
+		defer delete(visited, addr)
+	}
+
+	switch x := x.(type) {
+	case []interface{}:
+		return representArray(x, visited)
+	case map[string]interface{}:
+		return representMap(x, visited)
+	case string:
+		return strconv.Quote(x)
+	case int64:
+		return strconv.FormatInt(x, 10)
+	case float64:
+		return strconv.FormatFloat(x, 'G', -1, 64)
+	case nil:
+		return "null"
+	case bool:
+		return strconv.FormatBool(x)
+	default:
+		return fmt.Sprintf("unknown %#v %s", v, reflect.TypeOf(x).Name())
+	}
+}
+
+func representArray(x []interface{}, visited map[unsafe.Pointer]struct{}) string {
+	var buf bytes.Buffer
+	buf.WriteString("[")
+
+	needComma := false
+	for _, v := range x {
+		if needComma {
+			buf.WriteString(",")
+		} else {
+			needComma = true
+		}
+		buf.WriteString(represent(v, visited))
+	}
+	buf.WriteString("]")
+
+	return buf.String()
+}
+
+func representMap(x map[string]interface{}, visited map[unsafe.Pointer]struct{}) string {
+	var buf bytes.Buffer
+	buf.WriteString("{")
+
+	keys := make([]string, 0, len(x))
+	for k := range x {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	needComma := false
+	for _, k := range keys {
+		if needComma {
+			buf.WriteString(",")
+		} else {
+			needComma = true
+		}
+		v := x[k]
+		buf.WriteString(represent(k, visited))
+		buf.WriteString(":")
+		buf.WriteString(represent(v, visited))
+	}
+	buf.WriteString("}")
+
+	return buf.String()
+}

--- a/vm/repr.go
+++ b/vm/repr.go
@@ -10,7 +10,11 @@ import (
 )
 
 // Represent returns a string containing a printable representation
-// of a value.
+// of a value. It detects circular references. In that case, it returns
+// a "[Circular]".
+//
+// Map's keys are sorted so that multiple calls on a map should produce
+// the same result.
 func Represent(x Value) string {
 	return represent(x, make(map[unsafe.Pointer]struct{}))
 }

--- a/vm/repr_test.go
+++ b/vm/repr_test.go
@@ -1,0 +1,49 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRepresentString(t *testing.T) {
+	assert.Equal(t, `"hello world"`, Represent("hello world"))
+}
+
+func TestRepresentInt(t *testing.T) {
+	assert.Equal(t, "-42", Represent(int64(-42)))
+}
+
+func TestRepresentFloat(t *testing.T) {
+	assert.Equal(t, "3.14", Represent(float64(3.14)))
+}
+
+func TestRepresentNull(t *testing.T) {
+	assert.Equal(t, "null", Represent(nil))
+}
+
+func TestRepresentBool(t *testing.T) {
+	assert.Equal(t, "true", Represent(true))
+	assert.Equal(t, "false", Represent(false))
+}
+
+func TestRepresentArrayAndMap(t *testing.T) {
+	assert.Equal(t, `[3.14,true,null,"hello world",{"ans":42}]`, Represent([]interface{}{
+		float64(3.14),
+		true,
+		nil,
+		"hello world",
+		map[string]interface{}{"ans": int64(42)},
+	}))
+}
+
+func TestRepresentCircularStructure(t *testing.T) {
+	v := make(map[string]interface{})
+	v["foo"] = []interface{}{v}
+	v["zoo"] = int64(42)
+	assert.Equal(t, `{"foo":[[Circular]],"zoo":42}`, Represent(v))
+}
+
+func TestRepresentUnknownType(t *testing.T) {
+	assert.Equal(t, `unknown 0 int32`, Represent(int32(0)))
+}

--- a/vm/state.go
+++ b/vm/state.go
@@ -1,0 +1,8 @@
+package vm
+
+// State is an opaque structure representing Gates state.
+type State struct {
+	top   int       // first free slot in the stack
+	ci    *CallInfo // call info for current function
+	oldPC int
+}

--- a/vm/types.go
+++ b/vm/types.go
@@ -1,0 +1,4 @@
+package vm
+
+// Value represents a Gates value.
+type Value interface{}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -1,0 +1,1 @@
+package vm


### PR DESCRIPTION
I am planning to rewrite the Gates VM:

1. Since Gates does not need JIT compilation, a register-based VM is a better choice.
2. Current virtual machine is not well-designed; I would like to standardize the Gates opcode layout.

After rewriting the VM, I would start implementing the compiler with Gates itself (since the VM will be an individual part that taking Gates binary files as the input).